### PR TITLE
MultiVerse compatibility for onPlayerRespawn event

### DIFF
--- a/src/me/ellbristow/SimpleSpawn/SimpleSpawn.java
+++ b/src/me/ellbristow/SimpleSpawn/SimpleSpawn.java
@@ -1604,7 +1604,7 @@ public class SimpleSpawn extends JavaPlugin implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerRespawn(PlayerRespawnEvent event) {
         Player player = event.getPlayer();
         Location respawn;


### PR DESCRIPTION
I Set Event Priority for OnPlayerRespawn to EventPriority.LOWSET to allow compatibility with MultiVerse. MultiVerse event priority is set to EventPriority.LOW and therefore SimpleSpawn takes priority over MultiVerse.

This causes a problem when dealing with multiple worlds, when you die in world B instead of respawning in world B you respawn at your home location in World A. 

This is an easy way to allow for MultiVerse onPlayerRespawn to set the players Respawn point instead of SimapleSpawn.
